### PR TITLE
added vendor prefix to solve the sidebar is not displaying on iOS device...

### DIFF
--- a/_sass/a-smallscreen.sass
+++ b/_sass/a-smallscreen.sass
@@ -4,6 +4,8 @@
     left: -$sidebar-width
     &.open
       transform: translateX(100%)
+      -webkit-transform: translateX(100%)
+      
   #main
     width: 100%
   #menu

--- a/_sass/b-mobile.sass
+++ b/_sass/b-mobile.sass
@@ -6,6 +6,7 @@
     overflow: auto
     -webkit-overflow-scrolling: touch
     transition: transform .25s $time-function
+    -webkit-transition: -webkit-transform .25s $time-function
     &-left, &-right
       float: none
       width: 100%


### PR DESCRIPTION
之前因为坑爹 safari 要 vendor-prefix 所以右上角的 toggle button 怎么点都没有用。 加了这么简单两句之后 iPhone 就可以正常 toggle sidebar 了