### PR TITLE
Adding highlighter: rouge in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ url: "http://yourdomain.com" # the base hostname & protocol for your site
 # Sidebar filter
 # Choose 'tag' or 'category' as filter in sidebar.
 filter: 'tag'
-
+highlighter: rouge
 
 # Social account
 # twitter:  username


### PR DESCRIPTION
When I upgrade from old version and generate the jekyll at localhost
Something wrong happened in yajl:

Liquid Exception: cannot load such file -- yajl/yajl in _posts/2015-03-08-welcome-to-jekyll.markdown
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `require': cannot load such file -- yajl/yajl (LoadError)

I update the yajl but the situation does not change.So we can install rouge: gem install rouge

Adding one line in _config.yml. Then the jekyll could generate at localhost.

Signed-off-by: Li Zhaozhong ldm5235@gmail.com
